### PR TITLE
--agree-dev-preview no longer needed

### DIFF
--- a/commands
+++ b/commands
@@ -13,7 +13,7 @@ case "$1" in
     docker run -it --rm -p 443:443 -p 80:80 --name letsencrypt \
             -v "/etc/letsencrypt:/etc/letsencrypt" \
             -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
-            quay.io/letsencrypt/letsencrypt:latest --agree-dev-preview --server https://acme-v01.api.letsencrypt.org/directory -d $DOMAIN auth
+            quay.io/letsencrypt/letsencrypt:latest -d $DOMAIN auth
 
     cp "/etc/letsencrypt/live/$DOMAIN/privkey.pem" "$DOKKU_ROOT/$APP/tls/server.key"
     cp "/etc/letsencrypt/live/$DOMAIN/fullchain.pem" "$DOKKU_ROOT/$APP/tls/server.crt"


### PR DESCRIPTION
Let's Encrypt entered public beta, so `--agree-dev-preview` is no longer needed.
